### PR TITLE
Optimize maximization functions by using a single which.max

### DIFF
--- a/tests/testthat/test-maxAndTune.R
+++ b/tests/testthat/test-maxAndTune.R
@@ -324,3 +324,18 @@ test_that("Suite 1. Finetune_maxima unchanged", {
 
 })
 
+
+context("Testing idxToRowCol")
+
+test_that("idxToRowCol is correct for every index of a matrix.", {
+  test.rows <- 5
+  test.cols <- 7
+  for (i in 1:test.rows){
+    for (j in 1:test.cols){
+      x <- matrix(NA, test.rows, test.cols)
+      x[i,j] <- 1
+      wm <- which.max(x)
+      expect_equal(idxToRowCol(wm, test.rows), c(i,j))
+    }
+  }
+})


### PR DESCRIPTION
Previously, maxAndTune did 3 operations in its while loop that required scanning an entire similarity matrix:

1. all(is.na())
2. max()
3. which() to find the index of the maximum found in (2)

These can all be combined into a single which.max
1. It will return integer(0) if the matrix is all NA, which can be which can be checked to do (1)
2. The index can be used to pull the maximum value in constant time to do (2)
3. It returns* (3)

\* - technically it returns the index as if the matrix was strung out into a vector, which you can then easily convert back to a row/column index. See the idxToRowCol function for more.

finetune_maxima also did the last 2 and is fixed as well.


For function naming, I saw camelCase (e.g. `scaleTemplate`), words separated by periods (e.g. `get.x.smoothed`), and words separated by underscores (e.g. `finetune_maxima`). Seemed like camelCase was most common so I went with that, though let me know if something else is preferred.



Profiled code:

Before:
![max_before](https://github.com/martakarass/adept/assets/20176218/9c248048-dc4b-4d51-a46c-5b11c3e4bcd6)
After:
![max_after](https://github.com/martakarass/adept/assets/20176218/771fa8a1-c183-4e4b-b7a4-249d717d18d2)