### PR TITLE
Remove redundant unlists

### DIFF
--- a/R/segmentWalking.R
+++ b/R/segmentWalking.R
@@ -182,9 +182,9 @@ segmentWalking <- function(xyz,
   out_desc <- matrix(nrow = nrow(out), ncol = 5)
   for (i in 1:nrow(out)){  # i <- 1
     # i-th identified pattern: ADEPT result
-    tau_i <- unlist(out[i, "tau_i"])
-    T_i   <- unlist(out[i, "T_i"])
-    sim_i <- unlist(out[i, "sim_i"])
+    tau_i <- out[i, "tau_i"]
+    T_i   <- out[i, "T_i"]
+    sim_i <- out[i, "sim_i"]
     idx_i <- tau_i : (tau_i + T_i - 1)
     # pull i-th identified pattern data current
     xyzptr_stride1 <- xyzptr[idx_i, ]


### PR DESCRIPTION
Not really a major optimization, just saw that these didn't seem to be doing anything.


Profile showing unlists:
![unlists](https://github.com/martakarass/adept/assets/20176218/752a509a-6569-4651-a2c1-3c73a2e7a3e9)
